### PR TITLE
Release 0.6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,17 @@ os: osx
 osx_image: xcode6.4
 
 env:
+  matrix:
+    
+    - CONDA_NPY=111  CONDA_PY=27
+    - CONDA_NPY=112  CONDA_PY=27
+    - CONDA_NPY=113  CONDA_PY=27
+    - CONDA_NPY=111  CONDA_PY=35
+    - CONDA_NPY=112  CONDA_PY=35
+    - CONDA_NPY=113  CONDA_PY=35
+    - CONDA_NPY=111  CONDA_PY=36
+    - CONDA_NPY=112  CONDA_PY=36
+    - CONDA_NPY=113  CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "sYR9Zsc3Le6sez3kzKHu6nJJwrrrON8GqYAdx/m2HVthM7srogDczawcqp3pSPoYelyNaT/dvY+TNF6LQYhv3eeOFo/Itz3EJoqO+5g2BdMukTdrLDGq2HP1JWbwIfdD74EgzbGjjRYQRSUskhtMkBtvuZRE4iAJr8m+Lhy4k1JgwafhsGzXQUe+1CcNFiByDVGbEQZB+WxQRT9OVMKEHFd046/dgOLNcjuifSWMOgoKzdieefhqGoPR63AZU78cQi+jfESPI6aZxb6fgqDJKKxpeX2qp0PjehudEoYoWrro2CSmdibtUuLpN0FpHbCPh1vYnY0IQlw1QxXFKU+/RoCVEL6YoxJnoN1cbGMcsYySLnDL5ip8ZUEjg2mEqO5ZZZqKDafFQnUz4M2VAMi+Y+f/o0zApxWwE3eXUoAZ+kZAMi7DBWHNxGloJEpd9/aH2egYXs09AOyc21XpRQlcOLxmJ9k6sibbQKHli0TPrsUjH2OvrwyQPCHnFX/+hwACkrRjDnShUTFB0R2jk2Hh5giCeqIc4EMQYLqAI+aOsgp+jN6KdiSa80FNxRIf5fEoFF4HKHxrRbzkGQINvyyItCs5qpqrztge6HbI3Sv62wlDtsVBMav0eo4BoeZRPJw79drx05VnO8MSZ0vxl+mhtXzMg5Fa67U2PE15H374yN4="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,94 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
+      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 112
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 113
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 112
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 113
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 112
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 113
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,7 +57,67 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 9 case(s).
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=112
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=113
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=112
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=113
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=112
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=113
+    export CONDA_PY=36
+    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,3 @@
-#
-# All noted sections must be uncommented in the next release.
-# Also a re-rendering will be required after committing the
-# uncommented portions
-#
-# ref: https://github.com/conda-forge/conda-smithy#re-rendering-an-existing-feedstock
-#
-
-
 {% set version = "0.6.5" %}
 
 package:
@@ -20,34 +11,25 @@ source:
 
 build:
   number: 0
-  ###############################
-  # Uncomment on next release.  #
-  ###############################
-  # script:
-  #  - export CFLAGS="${CFLAGS} -I${PREFIX}/include -L${PREFIX}/lib"  # [unix]
-  #  - python setup.py install --single-version-externally-managed --record record.txt
+  script:
+    - export CFLAGS="${CFLAGS} -I${PREFIX}/include -L${PREFIX}/lib"  # [unix]
+    - python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
-    ###############################
-    # Uncomment on next release.  #
-    ###############################
-    # - toolchain
-    # - python
-    # - cython >=0.25
-    # - numpy x.x
-    # - mako
-    # - setuptools
+    - toolchain
+    - python
+    - cython >=0.25
+    - numpy x.x
+    - mako
+    - setuptools
     - libgpuarray =={{ version }}
 
   run:
-    ###############################
-    # Uncomment on next release.  #
-    ###############################
-    # - python
-    # - numpy x.x
-    # - mako
-    # - six
+    - python
+    - numpy x.x
+    - mako
+    - six
     - libgpuarray =={{ version }}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.5" %}
+{% set version = "0.6.8" %}
 
 package:
   name: pygpu
@@ -7,7 +7,7 @@ package:
 source:
   fn: libgpuarray-{{ version }}.tar.gz
   url: https://github.com/Theano/libgpuarray/archive/v{{ version }}.tar.gz
-  sha256: 29f44957a826083954d01de7009083fec4acb904bc51b48d3c667ef52c1f2c0b
+  sha256: a06744e02638ec1e579f7339be3e6c688d0e92b4ee15a9d7dec6bd43601d2554
 
 build:
   number: 0


### PR DESCRIPTION
Fixes https://github.com/conda-forge/libgpuarray-feedstock/issues/2

* Releases `pygpu` 0.6.8.
* Change the recipe to build Python/NumPy combinations (instead of being a metapackage).
* Re-render with `conda-smithy` 2.3.2 to regenerate the CI matrices.

Note: This will only work after PR ( https://github.com/conda-forge/libgpuarray-feedstock/pull/5 ) is merged and packages for `libgpuarray` 0.6.8 are available.